### PR TITLE
Adding Render Props & Bug Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxcast-sdk-react-native",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "BoxCast components for React Native",
   "main": "index.js",
   "scripts": {

--- a/src/BroadcastModalView.js
+++ b/src/BroadcastModalView.js
@@ -117,6 +117,22 @@ export default class BroadcastModalView extends Component<Props> {
     }
   }
 
+  renderDefaultView() {
+    return (
+      <View style={this.props.styles.fullScreen} pointerEvents="box-none">
+        <Animated.View style={this.props.videoStyles} {...this.props.animationProps}>
+          {<BroadcastVideo {...this.props} />}
+        </Animated.View>
+        <Animated.ScrollView style={[styles.detailsBox, this.props.transforms.details]}>
+          <BroadcastDetails {...this.props} />
+          <TouchableOpacity
+            style={[styles.dismissButton, this.props.dismissStyle]}
+            onPress={() => this.props.onDismiss()}><Text>{this.props.dismissText}</Text></TouchableOpacity>
+        </Animated.ScrollView>
+      </View>
+    );
+  }
+
   render() {
     const animationProps = this._panResponder.panHandlers;
     const transforms = this._computeDraggedTransforms();
@@ -126,18 +142,12 @@ export default class BroadcastModalView extends Component<Props> {
       { backgroundColor: '#000000' },
     ];
 
+    const videoProps = {...this.props, ...animationProps, transforms, videoStyles, styles};
+
     return (
-      <View style={styles.fullScreen} pointerEvents="box-none">
-        <Animated.View style={videoStyles} {...animationProps}>
-          {<BroadcastVideo {...this.props} />}
-        </Animated.View>
-        <Animated.ScrollView style={[styles.detailsBox, transforms.details]}>
-          <BroadcastDetails {...this.props} />
-          <TouchableOpacity
-            style={[styles.dismissButton, this.props.dismissStyle]}
-            onPress={() => this.props.onDismiss()}><Text>{this.props.dismissText}</Text></TouchableOpacity>
-        </Animated.ScrollView>
-      </View>
+      this.props.renderView
+        ? this.props.renderView(videoProps)
+        : this.renderDefaultView()
     );
   }
 

--- a/src/BroadcastModalView.js
+++ b/src/BroadcastModalView.js
@@ -41,11 +41,13 @@ export default class BroadcastModalView extends Component<Props> {
     dragAcceleration: 1.5,
   };
 
-  state = {
-    docked: false,
-  };
+  constructor(props) {
+    super(props);
 
-  componentWillMount() {
+    this.state = {
+      docked: false,
+    };
+
     this._initPanResponder();
   }
 

--- a/src/ChannelList.js
+++ b/src/ChannelList.js
@@ -41,7 +41,7 @@ export default class ChannelList extends Component<Props> {
   state = {
     broadcasts: [],
     error: null,
-    page: 1,
+    page: 0,
     loading: true,
     refreshing: false,
     loadingMore: false,
@@ -110,7 +110,7 @@ export default class ChannelList extends Component<Props> {
 
   _handleRefresh() {
     this.setState(
-      {broadcasts: [], page: 1, refreshing: true, hasMorePages: true},
+      {broadcasts: [], page: 0, refreshing: true, hasMorePages: true},
       () => this._fetch()
     );
   }

--- a/src/ChannelList.js
+++ b/src/ChannelList.js
@@ -68,7 +68,7 @@ export default class ChannelList extends Component<Props> {
                   }}
                   data={broadcasts}
                   horizontal={this.props.horizontal}
-                  renderItem={({item}) => this.renderBroadcast(item)}
+                  renderItem={this.props.renderItem ? this.props.renderItem : ({item}) => this.renderBroadcast(item)}
                   keyExtractor={(item, index) => item.id}
                   onEndReached={() => this._handleLoadMore()}
                   onEndReachedThreshold={0.5}

--- a/src/ChannelList.js
+++ b/src/ChannelList.js
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   Text,
   View,
+  RefreshControl,
 } from 'react-native';
 import { api } from 'boxcast-sdk-js';
 import BroadcastPreview from './BroadcastPreview';
@@ -74,8 +75,13 @@ export default class ChannelList extends Component<Props> {
                   onEndReachedThreshold={0.5}
                   initialNumToRender={this.props.pageSize}
                   ListFooterComponent={() => this._renderFooter()}
-                  refreshing={refreshing}
-                  onRefresh={() => this._handleRefresh()}
+                  refreshControl={
+                    <RefreshControl
+                      refreshing={refreshing}
+                      onRefresh={() => this._handleRefresh()}
+                      {...this.props.refreshControlProps}
+                    />
+                  }
             />
       </View>
     );
@@ -100,12 +106,17 @@ export default class ChannelList extends Component<Props> {
   }
 
   _renderFooter() {
-    if (!this.state.loadingMore) return null;
-    return (
-      <View style={styles.footerLoading}>
-        <ActivityIndicator animating size="large" />
-      </View>
-    );
+    if (!this.state.loadingMore) {
+      return null;
+    } else if (this.props.renderFooter) {
+      return this.props.renderFooter();
+    } else {
+      return (
+        <View style={styles.footerLoading}>
+          <ActivityIndicator animating size="large" />
+        </View>
+      );
+    }
   }
 
   _handleRefresh() {

--- a/src/ChannelList.js
+++ b/src/ChannelList.js
@@ -64,6 +64,7 @@ export default class ChannelList extends Component<Props> {
               this.setState({width, height})
             }}>
         {error ? <Text style={styles.error}>{error}</Text> : null}
+        {loading && !refreshing && this.props.loader}
         <FlatList style={{width: '100%'}}
                   contentContainerStyle={{
                   }}


### PR DESCRIPTION
Includes some changes I needed to make to allow for additional customizations:

**ChannelList**
- Added support for renderItem prop
- Added support for renderFooter prop
- Added support for custom loader prop

**BroadcastModalView**
- Added support for renderView prop

**Bugs**
- Looks like the initial page parameter for our broadcast query should be 0 instead of 1 (at least to have things match the web app).
- Moved the _initPanResponder call from componentWillMount to the constructor as React is deprecating that lifecycle hook.